### PR TITLE
Hook up with new connections endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ composer require workos/workos-php
 The package will need to be configured with your [API Key](https://dashboard.workos.com/api-keys) and [Project ID](https://dashboard.workos.com/sso/configuration). By default, the packages looks for a `WORKOS_API_KEY` and `WORKOS_PROJECT_ID` environment variable.
 
 ### SSO
-The package offers the following convenience functions to utilize WorkOS SSO.
-
-First we'll want to generate an OAuth 2.0 Authorization URL to initiate the SSO workflow with:
+To generate an OAuth 2.0 Authorization URL to initiate the SSO workflow with:
 
 ```php
 $url = (new \WorkOS\SSO())->getAuthorizationUrl(
@@ -29,15 +27,21 @@ $url = (new \WorkOS\SSO())->getAuthorizationUrl(
 );
 ```
 
-After directing the user to the Authorization URL and successfully completing the SSO workflow, use 
-the code passed back from WorkOS to grab the profile of the authenticated user to verify all is good:
+Using the code provided by WorkOS after going through the OAuth 2.0 workflow, grab the profile of the
+authenticated user to verify all is good:
 
 ```php
 $profile = (new \WorkOS\SSO())->getProfile($code);
 ```
 
+To create a connection using the token passed back from the WorkOS.js embed.
+
+```php
+$connection = $sso->createConnection($token);
+```
+
 ### Audit Trail
-Creating an Audit Trail event in WorkOS is as simple as running the following:
+To create an Audit Trail event in WorkOS:
 
 ```php
 $now = (new \DateTime())->format(\DateTime::ISO8601);

--- a/lib/Resource/Connection.php
+++ b/lib/Resource/Connection.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class Connection.
+ */
+class Connection extends BaseWorkOSResource
+{
+    const RESOURCE_TYPE = "connection";
+
+    const RESOURCE_ATTRIBUTES = [
+        "id",
+        "domains",
+        "status",
+        "name",
+        "connectionType",
+        "oauthUid",
+        "oauthSecret",
+        "oauthRedirectUri",
+        "samlEntityId",
+        "samlIdpUrl",
+        "samlRelyingPartyTrustCert",
+        "samlX509Certs"
+    ];
+
+    const RESPONSE_TO_RESOURCE_KEY = [
+        "id" => "id",
+        "status" => "status",
+        "name" => "name",
+        "connection_type" => "connectionType",
+        "oauth_uid" => "oauthUid",
+        "oauth_secret" => "oauthSecret",
+        "oauth_redirect_uri" => "oauthRedirectUri",
+        "saml_entity_id" => "samlEntityId",
+        "saml_idp_url" => "samlIdpUrl",
+        "saml_relying_party_trust_cert" => "samlRelyingPartyTrustCert",
+        "saml_x509_certs" => "samlX509Certs"
+    ];
+
+    public static function constructFromResponse($response)
+    {
+        $instance = parent::constructFromResponse($response);
+
+        $rawDomains = $response["domains"];
+        $domains = [];
+        foreach ($rawDomains as $rawDomain) {
+            \array_push($domains, Domain::constructFromResponse($rawDomain));
+        }
+
+        $instance->values["domains"] = $domains;
+
+        return $instance;
+    }
+
+    public function toArray()
+    {
+        $connectionArray = parent::toArray();
+
+        $domains = [];
+        foreach ($connectionArray["domains"] as $domain) {
+            \array_push($domains, $domain->toArray());
+        }
+
+        $connectionArray["domains"] = $domains;
+
+        return $connectionArray;
+    }
+}

--- a/lib/Resource/Domain.php
+++ b/lib/Resource/Domain.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class Domain.
+ */
+class Domain extends BaseWorkOSResource
+{
+    const RESOURCE_TYPE = "connection_domain";
+
+    const RESOURCE_ATTRIBUTES = [
+        "id",
+        "domain"
+    ];
+
+    const RESPONSE_TO_RESOURCE_KEY = [
+        "id" => "id",
+        "domain" => "domain"
+    ];
+}

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -76,7 +76,7 @@ class SSO
     }
 
     /**
-     * Promote a Draft Connection created through the WorkOS.js embed.
+     * @deprecated Promote a Draft Connection created through the WorkOS.js embed.
      *
      * @param string $token Token returned by WorkOS when a Draft Connection is
      * created in the WorkOS.js.embed
@@ -89,10 +89,36 @@ class SSO
      */
     public function promoteDraftConnection($token)
     {
+        $msg = "[DEPRECATED] SSO->promoteDraftConnection is deprecated. Use SSO->createConnection instead.";
+        \trigger_error($msg, E_USER_WARNING);
+        
         $promoteDraftConnectionPath = "draft_connections/${token}/activate";
 
         Client::request(Client::METHOD_POST, $promoteDraftConnectionPath, null, null, true);
 
         return true;
+    }
+
+    /**
+     * Create a Connection.
+     *
+     * @param string $source Token returned by WorkOS as a result of the WorkOS.js embed workflow.
+     *
+     * @throws \WorkOS\Exception\GenericException if an error internal to the SDK is encountered
+     * @throws \WorkOS\Exception\ServerException if an error internal to WorkOS is encountered
+     * @throws \WorkOS\Exception\NotFoundException if a Draft Connection could not be found
+     *
+     * @return \WorkOS\Resource\Connection
+     */
+    public function createConnection($source)
+    {
+        $connectionPath = "connections";
+        $params = [
+            "source" => $source
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $connectionPath, null, $params, true);
+
+        return Resource\Connection::constructFromResponse($response);
     }
 }

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     const SDK_IDENTIFIER = "WorkOS PHP";
-    const SDK_VERSION = '0.3.0';
+    const SDK_VERSION = '0.3.1';
 }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -90,7 +90,31 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             true
         );
 
-        $this->assertTrue($this->sso->promoteDraftConnection($token));
+        $this->assertTrue(@$this->sso->promoteDraftConnection($token));
+    }
+
+    public function testCreateConnectionReturnsConnectionWithExpectedValues()
+    {
+        $source = "source";
+
+        $path = "connections";
+        $params = ["source" => $source];
+
+        $result = $this->createConnectionResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $path,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $connection = $this->sso->createConnection($source);
+        $connectionFixture = $this->connectionFixture();
+
+        $this->assertSame($connectionFixture, $connection->toArray());
     }
 
     // Providers
@@ -130,6 +154,54 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "lastName" => "cha",
             "connectionType" => "GoogleOAuth",
             "idpId" => "randomalphanum"
+        ];
+    }
+
+    private function createConnectionResponseFixture()
+    {
+        return json_encode([
+            "object" => "connection",
+            "id" => "conn_01E0CG2C820RP4VS50PRJF8YPX",
+            "status" => "linked",
+            "name" => "Google OAuth 2.0",
+            "connection_type" => "GoogleOAuth",
+            "oauth_uid" => "oauthuid",
+            "oauth_secret" => "oauthsecret",
+            "oauth_redirect_uri" => "http://localhost:7000/sso/oauth/google/GbQX1B6LWUYcsGiq6k20iCUMA/callback",
+            "saml_entity_id" => null,
+            "saml_idp_url" => null,
+            "saml_relying_party_trust_cert" => null,
+            "saml_x509_certs" => null,
+            "domains" => [
+                [
+                    "object" => "connection_domain",
+                    "id" => "conn_dom_01E2GCC7Q3KCNEFA2BW9MXR4T5",
+                    "domain" => "workos.com"
+                ]
+            ]
+        ]);
+    }
+
+    private function connectionFixture()
+    {
+        return [
+            "id" => "conn_01E0CG2C820RP4VS50PRJF8YPX",
+            "domains" => [
+              [
+                "id" => "conn_dom_01E2GCC7Q3KCNEFA2BW9MXR4T5",
+                "domain" => "workos.com"
+              ]
+            ],
+            "status" => "linked",
+            "name" => "Google OAuth 2.0",
+            "connectionType" => "GoogleOAuth",
+            "oauthUid" => "oauthuid",
+            "oauthSecret" => "oauthsecret",
+            "oauthRedirectUri" => "http://localhost:7000/sso/oauth/google/GbQX1B6LWUYcsGiq6k20iCUMA/callback",
+            "samlEntityId" => null,
+            "samlIdpUrl" => null,
+            "samlRelyingPartyTrustCert" => null,
+            "samlX509Certs" => null
         ];
     }
 }


### PR DESCRIPTION
# Overview
- Add new SSO method to use new connections endpoint for creating a connection from a draft connection token
- Deprecate promoteDraftConnection