### PR TITLE
Expose `connection_id` on Profile Objects

### DIFF
--- a/lib/Resource/Profile.php
+++ b/lib/Resource/Profile.php
@@ -25,7 +25,7 @@ class Profile extends BaseWorkOSResource
         "email" => "email",
         "first_name" => "firstName",
         "last_name" => "lastName",
-        "connetion_id" => "connectionId",
+        "connection_id" => "connectionId",
         "connection_type" => "connectionType",
         "idp_id" => "idpId",
         "raw_attributes" => "rawAttributes"

--- a/lib/Resource/Profile.php
+++ b/lib/Resource/Profile.php
@@ -14,6 +14,7 @@ class Profile extends BaseWorkOSResource
         "email",
         "firstName",
         "lastName",
+        "connectionId",
         "connectionType",
         "idpId",
         "rawAttributes"
@@ -24,6 +25,7 @@ class Profile extends BaseWorkOSResource
         "email" => "email",
         "first_name" => "firstName",
         "last_name" => "lastName",
+        "connetion_id" => "connectionId",
         "connection_type" => "connectionType",
         "idp_id" => "idpId",
         "raw_attributes" => "rawAttributes"

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     const SDK_IDENTIFIER = "WorkOS PHP";
-    const SDK_VERSION = '0.6.0';
+    const SDK_VERSION = '0.7.0';
 }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -139,6 +139,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
                 "email" => "hen@papagenos.com",
                 "first_name" => "hen",
                 "last_name" => "cha",
+                "connection_id" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
                 "connection_type" => "GoogleOAuth",
                 "idp_id" => "randomalphanum",
                 "raw_attributes" => array(
@@ -158,6 +159,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "email" => "hen@papagenos.com",
             "firstName" => "hen",
             "lastName" => "cha",
+            "connection_id" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
             "connectionType" => "GoogleOAuth",
             "idpId" => "randomalphanum",
             "rawAttributes" => array(

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -159,7 +159,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "email" => "hen@papagenos.com",
             "firstName" => "hen",
             "lastName" => "cha",
-            "connection_id" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
+            "connectionId" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
             "connectionType" => "GoogleOAuth",
             "idpId" => "randomalphanum",
             "rawAttributes" => array(


### PR DESCRIPTION
This PR introduces the following changes:

* Passes the `connection_id` Profile object attribute through to the SDK. We currently expose `connection_id` via the `/sso/token` API endpoint.
* Updates the SDK version to `0.7.0`.