### PR TITLE
Update version identifier to 0.8.x

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     const SDK_IDENTIFIER = "WorkOS PHP";
-    const SDK_VERSION = '0.7.0';
+    const SDK_VERSION = '0.8.1';
 }


### PR DESCRIPTION
Forgot to bump the version identifier in the last release