### PR TITLE
Add `GET /connections/:id`

### DIFF
--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -114,4 +114,26 @@ class SSO
 
         return Resource\Connection::constructFromResponse($response);
     }
+
+    /**
+     * Get a Connection.
+     *
+     * @param string $connection Connection ID
+     *
+     * @return \WorkOS\Resource\Connection
+     */
+    public function getConnection($connection)
+    {
+        $connectionPath = "connections/${connection}";
+
+        $response = Client::request(
+            Client::METHOD_GET,
+            $connectionPath,
+            null,
+            null,
+            true
+        );
+
+        return Resource\Connection::constructFromResponse($response);
+    }
 }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -264,7 +264,6 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "oauthRedirectUri" => "http://localhost:7000/sso/oauth/google/GbQX1B6LWUYcsGiq6k20iCUMA/callback"
         ];
     }
-<<<<<<< HEAD
 
     private function connectionResponseFixture()
     {
@@ -295,8 +294,6 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             ]
         ]);
     }
-||||||| ce6ca7f
-=======
 
     private function connectionsResponseFixture()
     {
@@ -334,5 +331,4 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             ],
         ]);
     }
->>>>>>> master
 }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -101,6 +101,28 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($connectionFixture, $connection->toArray());
     }
 
+    public function testGetConnection()
+    {
+        $connection = "connection_id";
+        $connectionPath = "connections/${connection}";
+
+        $result = $this->connectionResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $connectionPath,
+            null,
+            null,
+            true,
+            $result
+        );
+
+        $connection = $this->sso->getConnection($connection);
+        $connectionFixture = $this->connectionFixture();
+
+        $this->assertSame($connectionFixture, $connection->toArray());
+    }
+
     // Providers
 
     public function authorizationUrlTestProvider()
@@ -213,5 +235,35 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "oauthSecret" => "oauthsecret",
             "oauthRedirectUri" => "http://localhost:7000/sso/oauth/google/GbQX1B6LWUYcsGiq6k20iCUMA/callback",
         ];
+    }
+
+    private function connectionResponseFixture()
+    {
+        return json_encode([
+            "id" => "conn_01E0CG2C820RP4VS50PRJF8YPX",
+            "status" => "linked",
+            "name" => "Google OAuth 2.0",
+            "connection_type" => "GoogleOAuth",
+            "oidc_client_id" => null,
+            "oidc_client_secret" => null,
+            "oidc_discovery_endpoint" => null,
+            "oidc_redirect_uri" => null,
+            "saml_entity_id" => null,
+            "saml_idp_url" => null,
+            "saml_relying_party_private_key" => null,
+            "saml_relying_party_public_key" => null,
+            "saml_x509_certs" => null,
+            "organization_id" => "org_1234",
+            "oauth_uid" => "oauthuid",
+            "oauth_secret" => "oauthsecret",
+            "oauth_redirect_uri" => "http://localhost:7000/sso/oauth/google/GbQX1B6LWUYcsGiq6k20iCUMA/callback",
+            "domains" => [
+                [
+                    "object" => "connection_domain",
+                    "id" => "conn_dom_01E2GCC7Q3KCNEFA2BW9MXR4T5",
+                    "domain" => "workos.com"
+                ]
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to retrieve a single Connection using the WorkOS SSO REST API