### PR TITLE
Add `DELETE /connections/:id`

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -11,6 +11,7 @@ class Client
 {
     const METHOD_GET = "get";
     const METHOD_POST = "post";
+    const METHOD_DELETE = "delete";
 
     private static $_requestClient;
 

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -120,7 +120,7 @@ class SSO
      *
      * @param string $connection Connection ID
      *
-     * @return \WorkOS\Resource\Connection
+     * @return \WorkOS\Resource\Response
      */
     public function deleteConnection($connection)
     {
@@ -134,7 +134,7 @@ class SSO
             true
         );
 
-        return Resource\Connection::constructFromResponse($response);
+        return $response;
     }
 
     /**

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -114,4 +114,26 @@ class SSO
 
         return Resource\Connection::constructFromResponse($response);
     }
+
+    /**
+     * Delete a Connection.
+     *
+     * @param string $connection Connection ID
+     *
+     * @return \WorkOS\Resource\Connection
+     */
+    public function deleteConnection($connection)
+    {
+        $connectionPath = "connections/${connection}";
+
+        $response = Client::request(
+            Client::METHOD_DELETE,
+            $connectionPath,
+            null,
+            null,
+            true
+        );
+
+        return Resource\Connection::constructFromResponse($response);
+    }
 }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -151,6 +151,27 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($connection, $connections[0]->toArray());
     }
 
+    public function testDeleteConnection()
+    {
+        $connection = "connection_id";
+        $connectionPath = "connections/${connection}";
+        $responseCode = 204;
+
+        $this->mockRequest(
+            Client::METHOD_DELETE,
+            $connectionPath,
+            null,
+            null,
+            true,
+            null,
+            null,
+            $responseCode
+        );
+
+        $response = $this->sso->deleteConnection($connection);
+        $this->assertSame(204, $responseCode);
+    }
+
     // Providers
 
     public function authorizationUrlTestProvider()


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to delete a single Connection using the WorkOS SSO REST API