### PR TITLE
Remove Unneeded Attribute from `Directory` Interface

### DIFF
--- a/lib/Resource/Directory.php
+++ b/lib/Resource/Directory.php
@@ -16,7 +16,6 @@ class Directory extends BaseWorkOSResource
         "state",
         "type",
         "name",
-        "bearerToken",
         "domain"
     ];
 
@@ -27,7 +26,6 @@ class Directory extends BaseWorkOSResource
         "state" => "state",
         "type" => "type",
         "name" => "name",
-        "bearer_token" => "bearerToken",
         "domain" => "domain"
     ];
 }

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -173,7 +173,6 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             "state" => "linked",
             "type" => "gsuite directory",
             "name" => "Ri Jeong Hyeok",
-            "bearerToken" => null,
             "domain" => "crashlandingonyou.com",
         ];
     }


### PR DESCRIPTION
This PR introduces the following changes:

- Removes `bearer_token` attribute from Directory resource