### PR TITLE
Fixed WorkOs typo changed to WorkOS

### DIFF
--- a/lib/Util/Request.php
+++ b/lib/Util/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WorkOs\Util;
+namespace WorkOS\Util;
 
 class Request
 {


### PR DESCRIPTION
The file Util/Request.php has a typo:

namespace WorkOs\Util <-------- should be WorkOS\Util

submitting PR to fix this