### PR TITLE
Version bump for HTTP Delete method

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     const SDK_IDENTIFIER = "WorkOS PHP";
-    const SDK_VERSION = '0.9.4';
+    const SDK_VERSION = '0.9.5';
 }


### PR DESCRIPTION
Bumping version from 0.9.4 to 0.9.5 for the new HTTP Delete method for supporting deleting connections and deleting directories