### PR TITLE
Fixed bug reported by customer in DELETE Method

### DIFF
--- a/lib/RequestClient/CurlRequestClient.php
+++ b/lib/RequestClient/CurlRequestClient.php
@@ -48,7 +48,7 @@ class CurlRequestClient implements RequestClientInterface
 
                 $opts[\CURLOPT_CUSTOMREQUEST] = 'DELETE';
 
-                if (\count($params) > 0) {
+                if (!empty($params)) {
                     $encoded = Util\Util::encodeParameters($params);
                     $absUrl = "{$absUrl}?{$encoded}";
                 }


### PR DESCRIPTION
PR to fix a bug reported by customer - the count function is intended to be used with arrays and was causing a critical error for them, however it was just a warn in my initial application. Either way, I resolved the issue with the warning/error no longer occurring. 