### PR TITLE
Remove support for deprecated `projectID` parameter

### DIFF
--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -30,17 +30,10 @@ class SSO
             throw new Exception\UnexpectedValueException($msg);
         }
 
-        try {
-            $params = [
-                "client_id" => WorkOS::getClientId(),
-                "response_type" => "code"
-            ];
-        } catch (\WorkOS\Exception\ConfigurationException $e) {
-            $params = [
-                "client_id" => WorkOS::getProjectId(),
-                "response_type" => "code"
-            ];
-        }
+        $params = [
+            "client_id" => WorkOS::getClientId(),
+            "response_type" => "code"
+        ];
 
         if ($domain) {
             $params["domain"] = $domain;
@@ -76,21 +69,12 @@ class SSO
     {
         $profilePath = "sso/token";
 
-        try {
-            $params = [
-                "client_id" => WorkOS::getClientId(),
-                "client_secret" => WorkOS::getApikey(),
-                "code" => $code,
-                "grant_type" => "authorization_code"
-            ];
-        } catch (\WorkOS\Exception\ConfigurationException $e) {
-            $params = [
-                "client_id" => WorkOS::getProjectId(),
-                "client_secret" => WorkOS::getApikey(),
-                "code" => $code,
-                "grant_type" => "authorization_code"
-            ];
-        }
+        $params = [
+            "client_id" => WorkOS::getClientId(),
+            "client_secret" => WorkOS::getApikey(),
+            "code" => $code,
+            "grant_type" => "authorization_code"
+        ];
         
         $response = Client::request(Client::METHOD_POST, $profilePath, null, $params);
 

--- a/lib/WorkOS.php
+++ b/lib/WorkOS.php
@@ -20,11 +20,6 @@ class WorkOS
     private static $clientId = null;
 
     /**
-     * @var null|string WorkOS Project ID
-     */
-    private static $projectId = null;
-
-    /**
      * @var string WorkOS base API URL.
      */
     private static $apiBaseUrl = "https://api.workos.com/";
@@ -89,44 +84,6 @@ class WorkOS
     public static function setClientId($clientId)
     {
         self::$clientId = $clientId;
-    }
-
-    /**
-     * @deprecated
-     *
-     * @return null|string WorkOS Project ID
-     */
-    public static function getProjectId()
-    {
-        if (isset(self::$projectId)) {
-            $msg = "[DEPRECATED] Project ID is deprecated. Use Client ID instead.";
-            \trigger_error($msg, E_USER_WARNING);
-
-            return self::$projectId;
-        }
-
-        if (getenv("WORKOS_PROJECT_ID")) {
-            $msg = "[DEPRECATED] Project ID is deprecated. Use Client ID instead.";
-            \trigger_error($msg, E_USER_WARNING);
-
-            self::$projectId = getenv("WORKOS_PROJECT_ID");
-
-            return self::$projectId;
-        }
-
-        $msg = "\$clientId is required";
-        throw new \WorkOS\Exception\ConfigurationException($msg);
-    }
-
-    /**
-     * @param string $projectId WorkOS Project ID
-     */
-    public static function setProjectId($projectId)
-    {
-        $msg = "[DEPRECATED] Project ID is deprecated. Use Client ID instead.";
-        \trigger_error($msg, E_USER_WARNING);
-
-        self::$projectId = $projectId;
     }
 
     /**

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -17,7 +17,6 @@ trait TestHelper
     {
         WorkOS::setApiKey(null);
         WorkOS::setClientId(null);
-        @WorkOS::setProjectId(null);
 
         Client::setRequestClient($this->defaultRequestClient);
     }
@@ -29,10 +28,10 @@ trait TestHelper
         WorkOS::setApiKey($apiKey);
     }
 
-    protected function withApiKeyAndClientId($apiKey = "pk_secretsauce", $projectId = "client_pizza")
+    protected function withApiKeyAndClientId($apiKey = "pk_secretsauce", $clientId = "client_pizza")
     {
         WorkOS::setApiKey($apiKey);
-        WorkOS::setClientId($projectId);
+        WorkOS::setClientId($clientId);
     }
 
     // Requests


### PR DESCRIPTION
This PR removes support for the deprecated `projectID` parameter.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-165.