### PR TITLE
Rename `getProfile` to `getProfileAndToken`

### DIFF
--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -61,7 +61,7 @@ class BaseWorkOSResource
         }
 
         $msg = "${key} does not exist on " . static::class;
-        throw new UnexpectedValueException($msg);
+        throw new WorkOS\Exception\UnexpectedValueException($msg);
     }
 
     public function __isset($key)
@@ -81,6 +81,6 @@ class BaseWorkOSResource
         }
 
         $msg = "${key} does not exist on " . static::class;
-        throw new UnexpectedValueException($msg);
+        throw new WorkOS\Exception\UnexpectedValueException($msg);
     }
 }

--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WorkOS\Resource;
+use WorkOS\Exception;
 
 class BaseWorkOSResource
 {
@@ -61,7 +62,7 @@ class BaseWorkOSResource
         }
 
         $msg = "${key} does not exist on " . static::class;
-        throw new WorkOS\Exception\UnexpectedValueException($msg);
+        throw new UnexpectedValueException($msg);
     }
 
     public function __isset($key)
@@ -81,6 +82,6 @@ class BaseWorkOSResource
         }
 
         $msg = "${key} does not exist on " . static::class;
-        throw new WorkOS\Exception\UnexpectedValueException($msg);
+        throw new UnexpectedValueException($msg);
     }
 }

--- a/lib/Resource/BaseWorkOSResource.php
+++ b/lib/Resource/BaseWorkOSResource.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace WorkOS\Resource;
-use WorkOS\Exception;
 
 class BaseWorkOSResource
 {
@@ -62,7 +61,7 @@ class BaseWorkOSResource
         }
 
         $msg = "${key} does not exist on " . static::class;
-        throw new UnexpectedValueException($msg);
+        throw new \WorkOS\Exception\UnexpectedValueException($msg);
     }
 
     public function __isset($key)
@@ -82,6 +81,6 @@ class BaseWorkOSResource
         }
 
         $msg = "${key} does not exist on " . static::class;
-        throw new UnexpectedValueException($msg);
+        throw new \WorkOS\Exception\UnexpectedValueException($msg);
     }
 }

--- a/lib/Resource/ProfileAndToken.php
+++ b/lib/Resource/ProfileAndToken.php
@@ -7,8 +7,6 @@ namespace WorkOS\Resource;
  */
 class ProfileAndToken extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "profile";
-
     const RESOURCE_ATTRIBUTES = [
         "accessToken"
     ];

--- a/lib/Resource/ProfileAndToken.php
+++ b/lib/Resource/ProfileAndToken.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WorkOS\Resource;
+
+/**
+ * Class ProfileAndToken.
+ */
+class ProfileAndToken extends BaseWorkOSResource
+{
+    const RESOURCE_TYPE = "profile";
+
+    const RESOURCE_ATTRIBUTES = [
+        "accessToken"
+    ];
+
+    const RESPONSE_TO_RESOURCE_KEY = [
+        "access_token" => "accessToken"
+    ];
+
+    public static function constructFromResponse($response)
+    {
+        $instance = parent::constructFromResponse($response);
+
+        $instance->values["profile"] = Profile::constructFromResponse($response["profile"]);
+
+        return $instance;
+    }
+}

--- a/lib/Resource/ProfileAndToken.php
+++ b/lib/Resource/ProfileAndToken.php
@@ -8,7 +8,8 @@ namespace WorkOS\Resource;
 class ProfileAndToken extends BaseWorkOSResource
 {
     const RESOURCE_ATTRIBUTES = [
-        "accessToken"
+        "accessToken",
+        "profile"
     ];
 
     const RESPONSE_TO_RESOURCE_KEY = [

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -63,9 +63,9 @@ class SSO
      *
      * @param string $code Code returned by WorkOS on completion of OAuth 2.0 flow
      *
-     * @return \WorkOS\Resource\Profile
+     * @return \WorkOS\Resource\ProfileAndToken
      */
-    public function getProfile($code)
+    public function getProfileAndToken($code)
     {
         $profilePath = "sso/token";
 
@@ -78,7 +78,7 @@ class SSO
         
         $response = Client::request(Client::METHOD_POST, $profilePath, null, $params);
 
-        return Resource\Profile::constructFromResponse($response[Resource\Profile::RESOURCE_TYPE]);
+        return Resource\ProfileAndToken::constructFromResponse($response);
     }
 
     /**

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -64,7 +64,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             "grant_type" => "authorization_code"
         ];
 
-        $result = $this->profileResponseFixture();
+        $result = $this->profileAndTokenResponseFixture();
 
         $this->mockRequest(
             Client::METHOD_POST,
@@ -78,6 +78,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $profileAndToken = $this->sso->getProfileAndToken('code');
         $profileFixture = $this->profileFixture();
 
+        $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $profileAndToken->accessToken);
         $this->assertSame($profileFixture, $profileAndToken->profile->toArray());
     }
 
@@ -191,9 +192,10 @@ class SSOTest extends \PHPUnit\Framework\TestCase
 
     // Fixtures
 
-    private function profileResponseFixture()
+    private function profileAndTokenResponseFixture()
     {
         return json_encode([
+            "access_token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
             "profile" => [
                 "id" => "prof_hen",
                 "email" => "hen@papagenos.com",

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -53,7 +53,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedParams, $paramsArray);
     }
 
-    public function testGetProfileReturnsProfileWithExpectedValues()
+    public function testGetProfileAndTokenReturnsProfileWithExpectedValues()
     {
         $code = 'code';
         $path = "sso/token";
@@ -75,10 +75,10 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             $result
         );
 
-        $profile = $this->sso->getProfile('code');
+        $profileAndToken = $this->sso->getProfileAndToken('code');
         $profileFixture = $this->profileFixture();
 
-        $this->assertSame($profileFixture, $profile->toArray());
+        $this->assertSame($profileFixture, $profileAndToken->profile->toArray());
     }
 
     public function testCreateConnectionReturnsConnectionWithExpectedValues()


### PR DESCRIPTION
This PR renames the `getProfile` method to `getProfileAndToken`.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-158.