### PR TITLE
Move Organization operations to the top-level

### DIFF
--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace WorkOS;
+
+/**
+ * Class Portal.
+ *
+ * This class facilitates the use of operations on WorkOS Organizations.
+ */
+class Organizations
+{
+    const DEFAULT_PAGE_SIZE = 10;
+
+    /**
+     * List Organizations.
+     *
+     * @param null|array $domain Filter organizations to only return those that are associated with
+     *      the provided domain.
+     * @param int $limit Maximum number of records to return
+     * @param null|string $before Organization ID to look before
+     * @param null|string $after Organization ID to look after
+     *
+     * @return array An array containing the following:
+     *      null|string Organization ID to use as before cursor
+     *      null|string Organization ID to use as after cursor
+     *      array \WorkOS\Resource\Organization instances
+     */
+    public function listOrganizations(
+        $domains = null,
+        $limit = self::DEFAULT_PAGE_SIZE,
+        $before = null,
+        $after = null
+    ) {
+        $organizationsPath = "organizations";
+        $params = [
+          "limit" => $limit,
+          "before" => $before,
+          "after" => $after,
+          "domains" => $domains
+        ];
+
+        $response = Client::request(
+            Client::METHOD_GET,
+            $organizationsPath,
+            null,
+            $params,
+            true
+        );
+
+        $organizations = [];
+        list($before, $after) = Util\Request::parsePaginationArgs($response);
+        foreach ($response["data"] as $responseData) {
+            \array_push($organizations, Resource\Organization::constructFromResponse($responseData));
+        }
+
+        return [$before, $after, $organizations];
+    }
+
+    /**
+     * Create Organization.
+     *
+     * @param string $name The name of the Organization.
+     * @param array $domains The domains of the Organization.
+     *
+     * @return \WorkOS\Resource\Organization
+     */
+    public function createOrganization($name, $domains)
+    {
+        $organizationsPath = "organizations";
+        $params = [
+            "name" => $name,
+            "domains" => $domains
+        ];
+
+        $response = Client::request(Client::METHOD_POST, $organizationsPath, null, $params, true);
+
+        return Resource\Organization::constructFromResponse($response);
+    }
+
+    /**
+     * Update Organization.
+     *
+     * @param string $organization An Organization identifier.
+     * @param array $domains The domains of the Organization.
+     * @param string $name The name of the Organization.
+     */
+
+    public function updateOrganization($organization, $domains, $name)
+    {
+        $organizationsPath = "organizations/{$organization}";
+        $params = [
+          "organization" => $organization,
+          "domains" => $domains,
+          "name" => $name
+        ];
+
+        $response = Client::request(Client::METHOD_PUT, $organizationsPath, null, $params, true);
+
+        return Resource\Organization::constructFromResponse($response);
+    }
+}

--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -3,7 +3,7 @@
 namespace WorkOS;
 
 /**
- * Class Portal.
+ * Class Organizations.
  *
  * This class facilitates the use of operations on WorkOS Organizations.
  */

--- a/lib/Portal.php
+++ b/lib/Portal.php
@@ -9,29 +9,6 @@ namespace WorkOS;
  */
 class Portal
 {
-    const DEFAULT_PAGE_SIZE = 10;
-
-    /**
-     * Create Organization.
-     *
-     * @param string $name The name of the Organization.
-     * @param array $domains The domains of the Organization.
-     *
-     * @return \WorkOS\Resource\Organization
-     */
-    public function createOrganization($name, $domains)
-    {
-        $organizationsPath = "organizations";
-        $params = [
-            "name" => $name,
-            "domains" => $domains
-        ];
-
-        $response = Client::request(Client::METHOD_POST, $organizationsPath, null, $params, true);
-
-        return Resource\Organization::constructFromResponse($response);
-    }
-
     /**
      * Generate a Portal Link scoped to an Organization.
      *
@@ -54,72 +31,5 @@ class Portal
         $response = Client::request(Client::METHOD_POST, $generateLinkPath, null, $params, true);
 
         return Resource\PortalLink::constructFromResponse($response);
-    }
-
-    /**
-     * List Organizations.
-     *
-     * @param null|array $domain Filter organizations to only return those that are associated with
-     *      the provided domain.
-     * @param int $limit Maximum number of records to return
-     * @param null|string $before Organization ID to look before
-     * @param null|string $after Organization ID to look after
-     *
-     * @return array An array containing the following:
-     *      null|string Organization ID to use as before cursor
-     *      null|string Organization ID to use as after cursor
-     *      array \WorkOS\Resource\Organization instances
-     */
-    public function listOrganizations(
-        $domains = null,
-        $limit = self::DEFAULT_PAGE_SIZE,
-        $before = null,
-        $after = null
-    ) {
-        $organizationsPath = "organizations";
-        $params = [
-          "limit" => $limit,
-          "before" => $before,
-          "after" => $after,
-          "domains" => $domains
-        ];
-
-        $response = Client::request(
-            Client::METHOD_GET,
-            $organizationsPath,
-            null,
-            $params,
-            true
-        );
-
-        $organizations = [];
-        list($before, $after) = Util\Request::parsePaginationArgs($response);
-        foreach ($response["data"] as $responseData) {
-            \array_push($organizations, Resource\Organization::constructFromResponse($responseData));
-        }
-
-        return [$before, $after, $organizations];
-    }
-
-    /**
-     * Update Organization.
-     *
-     * @param string $organization An Organization identifier.
-     * @param array $domains The domains of the Organization.
-     * @param string $name The name of the Organization.
-     */
-
-    public function updateOrganization($organization, $domains, $name)
-    {
-        $organizationsPath = "organizations/{$organization}";
-        $params = [
-          "organization" => $organization,
-          "domains" => $domains,
-          "name" => $name
-        ];
-
-        $response = Client::request(Client::METHOD_PUT, $organizationsPath, null, $params, true);
-
-        return Resource\Organization::constructFromResponse($response);
     }
 }

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace WorkOS;
+
+class OrganizationsTest extends \PHPUnit\Framework\TestCase
+{
+    use TestHelper {
+        setUp as protected traitSetUp;
+    }
+
+    protected function setUp()
+    {
+        $this->traitSetUp();
+
+        $this->withApiKey();
+        $this->organizations = new Organizations();
+    }
+
+    public function testCreateOrganization()
+    {
+        $organizationsPath = "organizations";
+
+        $result = $this->createOrganizationResponseFixture();
+
+        $params = [
+            "name" => "Organization Name",
+            "domains" => array("example.com")
+        ];
+
+        $this->mockRequest(
+            Client::METHOD_POST,
+            $organizationsPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $organization = $this->organizationFixture();
+
+        $response = $this->organizations->createOrganization("Organization Name", array("example.com"));
+        $this->assertSame($organization, $response->toArray());
+    }
+
+    public function testListOrganizations()
+    {
+        $organizationsPath = "organizations";
+        $params = [
+            "limit" => Organizations::DEFAULT_PAGE_SIZE,
+            "before" => null,
+            "after" => null,
+            "domains" => null
+        ];
+
+        $result = $this->organizationsResponseFixture();
+
+        $this->mockRequest(
+            Client::METHOD_GET,
+            $organizationsPath,
+            null,
+            $params,
+            true,
+            $result
+        );
+
+        $organization = $this->organizationFixture();
+
+        list($before, $after, $organizations) = $this->organizations->listOrganizations();
+        $this->assertSame($organization, $organizations[0]->toArray());
+    }
+
+    // Fixtures
+
+    private function createOrganizationResponseFixture()
+    {
+        return json_encode([
+            "name" => "Organization Name",
+            "object" => "organization",
+            "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "domains" => [
+                [
+                    "object" => "organization_domain",
+                    "id" => "org_domain_01EHQMYV71XT8H31WE5HF8YK4A",
+                    "domain" => "example.com"
+                ]
+            ]
+        ]);
+    }
+
+    private function organizationsResponseFixture()
+    {
+        return json_encode([
+            "object" => "list",
+            "data" => [
+                [
+                "object" => "organization",
+                "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+                "name" => "Organization Name",
+                "domains" => [
+                    [
+                        "object" => "organization_domain",
+                        "id" => "org_domain_01EHQMYV71XT8H31WE5HF8YK4A",
+                        "domain" => "example.com"
+                    ]
+                ]
+                ],
+                [
+                "object" => "organization",
+                "id" => "org_01EHQMVDTC2GRAHFCCRNTSKH46",
+                "name" => "example2.com",
+                "domains" => [
+                    [
+                        "object" => "organization_domain",
+                        "id" => "org_domain_01EHQMVDTZVA27PK614ME4YK7V",
+                        "domain" => "example2.com"
+                    ]
+                ]
+                ],
+                [
+                "object" => "organization",
+                "id" => "org_01EGP9Z6RY2J6YE0ZV57CGEXV2",
+                "name" => "example5.com",
+                "domains" => [
+                    [
+                        "object" => "organization_domain",
+                        "id" => "org_domain_01EGP9Z6S6HVQ5CPD152GJBEA5",
+                        "domain" => "example5.com"
+                    ]
+                ]
+                ]
+            ],
+            "listMetadata" => [
+                "before" => "before-id",
+                "after" => null
+            ]
+        ]);
+    }
+
+    private function organizationFixture()
+    {
+        return [
+            "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "name" => "Organization Name",
+            "domains" => [
+                [
+                    "object" => "organization_domain",
+                    "id" => "org_domain_01EHQMYV71XT8H31WE5HF8YK4A",
+                    "domain" => "example.com"
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/WorkOS/PortalTest.php
+++ b/tests/WorkOS/PortalTest.php
@@ -16,32 +16,6 @@ class PortalTest extends \PHPUnit\Framework\TestCase
         $this->ap = new Portal();
     }
 
-    public function testCreateOrganization()
-    {
-        $organizationsPath = "organizations";
-
-        $result = $this->createOrganizationResponseFixture();
-
-        $params = [
-            "name" => "Organization Name",
-            "domains" => array("example.com")
-        ];
-
-        $this->mockRequest(
-            Client::METHOD_POST,
-            $organizationsPath,
-            null,
-            $params,
-            true,
-            $result
-        );
-
-        $organization = $this->organizationFixture();
-
-        $response = $this->ap->createOrganization("Organization Name", array("example.com"));
-        $this->assertSame($organization, $response->toArray());
-    }
-
     public function testGenerateLinkSSO()
     {
         $generateLinkPath = "portal/generate_link";
@@ -96,119 +70,12 @@ class PortalTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectation, $response->link);
     }
 
-    public function testListOrganizations()
-    {
-        $organizationsPath = "organizations";
-        $params = [
-            "limit" => Portal::DEFAULT_PAGE_SIZE,
-            "before" => null,
-            "after" => null,
-            "domains" => null
-        ];
-
-        $result = $this->organizationsResponseFixture();
-
-        $this->mockRequest(
-            Client::METHOD_GET,
-            $organizationsPath,
-            null,
-            $params,
-            true,
-            $result
-        );
-
-        $organization = $this->organizationFixture();
-
-        list($before, $after, $organizations) = $this->ap->listOrganizations();
-        $this->assertSame($organization, $organizations[0]->toArray());
-    }
-
     // Fixtures
-
-    private function createOrganizationResponseFixture()
-    {
-        return json_encode([
-            "name" => "Organization Name",
-            "object" => "organization",
-            "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
-            "domains" => [
-                [
-                    "object" => "organization_domain",
-                    "id" => "org_domain_01EHQMYV71XT8H31WE5HF8YK4A",
-                    "domain" => "example.com"
-                ]
-            ]
-        ]);
-    }
 
     private function generatePortalLinkFixture()
     {
         return json_encode([
             "link" => "https://id.workos.com/portal/launch?secret=secret"
         ]);
-    }
-
-    private function organizationsResponseFixture()
-    {
-        return json_encode([
-            "object" => "list",
-            "data" => [
-                [
-                "object" => "organization",
-                "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
-                "name" => "Organization Name",
-                "domains" => [
-                    [
-                        "object" => "organization_domain",
-                        "id" => "org_domain_01EHQMYV71XT8H31WE5HF8YK4A",
-                        "domain" => "example.com"
-                    ]
-                ]
-                ],
-                [
-                "object" => "organization",
-                "id" => "org_01EHQMVDTC2GRAHFCCRNTSKH46",
-                "name" => "example2.com",
-                "domains" => [
-                    [
-                        "object" => "organization_domain",
-                        "id" => "org_domain_01EHQMVDTZVA27PK614ME4YK7V",
-                        "domain" => "example2.com"
-                    ]
-                ]
-                ],
-                [
-                "object" => "organization",
-                "id" => "org_01EGP9Z6RY2J6YE0ZV57CGEXV2",
-                "name" => "example5.com",
-                "domains" => [
-                    [
-                        "object" => "organization_domain",
-                        "id" => "org_domain_01EGP9Z6S6HVQ5CPD152GJBEA5",
-                        "domain" => "example5.com"
-                    ]
-                ]
-                ]
-            ],
-            "listMetadata" => [
-                "before" => "before-id",
-                "after" => null
-            ]
-        ]);
-    }
-
-    private function organizationFixture()
-    {
-        return [
-            "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
-            "name" => "Organization Name",
-            "domains" => [
-                [
-                    "object" => "organization_domain",
-                    "id" => "org_domain_01EHQMYV71XT8H31WE5HF8YK4A",
-                    "domain" => "example.com"
-                ]
-            ]
-        ];
     }
 }


### PR DESCRIPTION
This PR moves the Organization operations to their own top-level class in the SDK.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-171.