### PR TITLE
Remove `createConnection` method

### DIFF
--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -82,29 +82,6 @@ class SSO
     }
 
     /**
-     * Create a Connection.
-     *
-     * @param string $source Token returned by WorkOS as a result of the WorkOS.js embed workflow.
-     *
-     * @throws \WorkOS\Exception\GenericException if an error internal to the SDK is encountered
-     * @throws \WorkOS\Exception\ServerException if an error internal to WorkOS is encountered
-     * @throws \WorkOS\Exception\NotFoundException if a Draft Connection could not be found
-     *
-     * @return \WorkOS\Resource\Connection
-     */
-    public function createConnection($source)
-    {
-        $connectionPath = "connections";
-        $params = [
-            "source" => $source
-        ];
-
-        $response = Client::request(Client::METHOD_POST, $connectionPath, null, $params, true);
-
-        return Resource\Connection::constructFromResponse($response);
-    }
-
-    /**
      * Delete a Connection.
      *
      * @param string $connection Connection ID

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -82,30 +82,6 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($profileFixture, $profileAndToken->profile->toArray());
     }
 
-    public function testCreateConnectionReturnsConnectionWithExpectedValues()
-    {
-        $source = "source";
-
-        $path = "connections";
-        $params = ["source" => $source];
-
-        $result = $this->createConnectionResponseFixture();
-
-        $this->mockRequest(
-            Client::METHOD_POST,
-            $path,
-            null,
-            $params,
-            true,
-            $result
-        );
-
-        $connection = $this->sso->createConnection($source);
-        $connectionFixture = $this->connectionFixture();
-
-        $this->assertSame($connectionFixture, $connection->toArray());
-    }
-
     public function testGetConnection()
     {
         $connection = "connection_id";
@@ -231,26 +207,6 @@ class SSOTest extends \PHPUnit\Framework\TestCase
                 "ipd_id" => "randomalphanum"
             )
         ];
-    }
-
-    private function createConnectionResponseFixture()
-    {
-        return json_encode([
-            "object" => "connection",
-            "id" => "conn_01E0CG2C820RP4VS50PRJF8YPX",
-            "state" => "active",
-            "status" => "linked",
-            "name" => "Google OAuth 2.0",
-            "connection_type" => "GoogleOAuth",
-            "organization_id" => "org_1234",
-            "domains" => [
-                [
-                    "object" => "connection_domain",
-                    "id" => "conn_dom_01E2GCC7Q3KCNEFA2BW9MXR4T5",
-                    "domain" => "workos.com"
-                ]
-            ]
-        ]);
     }
 
     private function connectionFixture()


### PR DESCRIPTION
This PR removes the deprecated `createConnection` method from the SDK.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-179.