### PR TITLE
Drop version 5.6.40 from semaphore test

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,12 +27,6 @@ blocks:
         commands:
           - checkout
       jobs:
-        - name: php 5.6
-          commands:
-            - phpbrew --no-progress install 5.6.40
-            - phpbrew use php-5.6.40
-            - bash scripts/restore-cache-and-update-deps 56
-            - php composer.phar run-script test
         - name: php 7.0
           commands:
             - phpbrew --no-progress install 7.0.33


### PR DESCRIPTION
PHPbrew no longer supports version 5.6.40, so the unit test returns an error on every execution:

Exception: Version 5.6.40 not found.
Trace:

    0) PhpBrew\Command\InstallCommand->execute('5.6.40')
    1) call_user_func_array([PhpBrew\Command\InstallCommand, 'execute'], ['5.6.40'])
    2) CLIFramework\CommandBase->executeWrapper(['5.6.40'])
    3) CLIFramework\Application->run(['/opt/homebrew/bin/phpbrew', '--no-progress', 'install', '5.6.40'])
    4) PhpBrew\Console->runWithTry(['/opt/homebrew/bin/phpbrew', '--no-progress', 'install', '5.6.40'])
    5) require('phar:///opt/homebrew/Cellar/phpbrew/1.27.0/bin/phpbrew/bin/phpbrew')

This is fine as version 5.6.40 was end of lifed back in January.