### PR TITLE
expose idp_id and groups for directory users

### DIFF
--- a/lib/Resource/DirectoryUser.php
+++ b/lib/Resource/DirectoryUser.php
@@ -16,7 +16,9 @@ class DirectoryUser extends BaseWorkOSResource
         "emails",
         "username",
         "lastName",
-        "state"
+        "state",
+        "idpId",
+        "groups"
     ];
 
     const RESPONSE_TO_RESOURCE_KEY = [
@@ -26,6 +28,8 @@ class DirectoryUser extends BaseWorkOSResource
         "emails" => "emails",
         "username" => "username",
         "last_name" => "lastName",
-        "state" => "state"
+        "state" => "state",
+        "idp_id" => "idpId",
+        "groups" => "groups"
     ];
 }

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -244,6 +244,8 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
                     "state" => "active",
                     "last_name" => "Seri",
                     "first_name" => "Yoon",
+                    "idp_id" => null,
+                    "groups" => null,
                     "emails" => [
                         [
                             "primary" => true,

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -327,7 +327,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
                     ]
                 ],
             ],
-            "id" => "directory_usr_id",
+            "id" => "directory_usr_id"
         ]);
     }
 

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -277,7 +277,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
                             ]
                         ],
                     ],
-                    "id" => "directory_usr_id"
+                    "id" => "directory_usr_id",
                 ]
             ]
         ]);
@@ -323,7 +323,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
                     ]
                 ],
             ],
-            "id" => "directory_usr_id"
+            "id" => "directory_usr_id",
         ]);
     }
 
@@ -367,7 +367,9 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             ],
             "username" => "yoon@seri.com",
             "lastName" => "Seri",
-            "state" => "active"
+            "state" => "active",
+            "idpId" => null, 
+            "groups" => null
         ];
     }
 }

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -277,7 +277,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
                             ]
                         ],
                     ],
-                    "id" => "directory_usr_id",
+                    "id" => "directory_usr_id"
                 ]
             ]
         ]);
@@ -290,6 +290,8 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             "state" => "active",
             "last_name" => "Seri",
             "first_name" => "Yoon",
+            "idp_id" => null,
+            "groups" => null,
             "emails" => [
                 [
                     "primary" => true,
@@ -368,7 +370,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             "username" => "yoon@seri.com",
             "lastName" => "Seri",
             "state" => "active",
-            "idpId" => null, 
+            "idpId" => null,
             "groups" => null
         ];
     }


### PR DESCRIPTION
There was no linear task to add idp_id for the PHP SDK, however I saw it in the API documentation so decided to also add this in while exposing groups. 