### PR TITLE
Fix GetProfileandToken returning 'raw' in payload 

### DIFF
--- a/lib/Resource/ProfileAndToken.php
+++ b/lib/Resource/ProfileAndToken.php
@@ -20,7 +20,7 @@ class ProfileAndToken extends BaseWorkOSResource
     {
         $instance = parent::constructFromResponse($response);
 
-        $instance->values["profile"] = Profile::constructFromResponse($response["profile"]);
+        $instance->values["profile"] = $response["profile"];
 
         return $instance;
     }

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -79,7 +79,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $profileFixture = $this->profileFixture();
 
         $this->assertSame("01DMEK0J53CVMC32CK5SE0KZ8Q", $profileAndToken->accessToken);
-        $this->assertSame($profileFixture, $profileAndToken->profile->toArray());
+        $this->assertSame($profileFixture, $profileAndToken->profile);
     }
 
     public function testGetConnection()
@@ -195,12 +195,12 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         return [
             "id" => "prof_hen",
             "email" => "hen@papagenos.com",
-            "firstName" => "hen",
-            "lastName" => "cha",
-            "connectionId" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
-            "connectionType" => "GoogleOAuth",
-            "idpId" => "randomalphanum",
-            "rawAttributes" => array(
+            "first_name" => "hen",
+            "last_name" => "cha",
+            "connection_id" => "conn_01EMH8WAK20T42N2NBMNBCYHAG",
+            "connection_type" => "GoogleOAuth",
+            "idp_id" => "randomalphanum",
+            "raw_attributes" => array(
                 "email" => "hen@papagenos.com",
                 "first_name" => "hen",
                 "last_name" => "cha",


### PR DESCRIPTION
getProfileAndToken is returning a payload that includes raw in the profile object which
is denormalizing the payload between OAuth payloads and SAML payloads. It looked like we were running $response[profile] through the constructFromResponse function twice so I reduced this to once and that resolved the issue in testing