### PR TITLE
Add support for `allowProfilesOutsideOrganization` for organizations

### DIFF
--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -61,15 +61,18 @@ class Organizations
      *
      * @param string $name The name of the Organization.
      * @param array $domains The domains of the Organization.
+     * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
+     *      that are outside of the Organization's configured User Email Domains.
      *
      * @return \WorkOS\Resource\Organization
      */
-    public function createOrganization($name, $domains)
+    public function createOrganization($name, $domains, $allowProfilesOutsideOrganization = null)
     {
         $organizationsPath = "organizations";
         $params = [
             "name" => $name,
-            "domains" => $domains
+            "domains" => $domains,
+            "allow_profiles_outside_organization" => $allowProfilesOutsideOrganization
         ];
 
         $response = Client::request(Client::METHOD_POST, $organizationsPath, null, $params, true);
@@ -83,15 +86,18 @@ class Organizations
      * @param string $organization An Organization identifier.
      * @param array $domains The domains of the Organization.
      * @param string $name The name of the Organization.
+     * @param null|boolean $allowProfilesOutsideOrganization Whether Connections within the Organization allow profiles
+     *      that are outside of the Organization's configured User Email Domains.
      */
 
-    public function updateOrganization($organization, $domains, $name)
+    public function updateOrganization($organization, $domains, $name, $allowProfilesOutsideOrganization = null)
     {
         $organizationsPath = "organizations/{$organization}";
         $params = [
           "organization" => $organization,
           "domains" => $domains,
-          "name" => $name
+          "name" => $name,
+          "allow_profiles_outside_organization" => $allowProfilesOutsideOrganization
         ];
 
         $response = Client::request(Client::METHOD_PUT, $organizationsPath, null, $params, true);

--- a/lib/Resource/Organization.php
+++ b/lib/Resource/Organization.php
@@ -13,12 +13,14 @@ class Organization extends BaseWorkOSResource
     const RESOURCE_ATTRIBUTES = [
         "id",
         "name",
+        "allow_profiles_outside_organization",
         "domains"
     ];
 
     const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "name" => "name",
+        "allow_profiles_outside_organization" => "allowProfilesOutsideOrganization",
         "domains" => "domains"
     ];
 }

--- a/lib/Resource/Organization.php
+++ b/lib/Resource/Organization.php
@@ -13,7 +13,7 @@ class Organization extends BaseWorkOSResource
     const RESOURCE_ATTRIBUTES = [
         "id",
         "name",
-        "allow_profiles_outside_organization",
+        "allowProfilesOutsideOrganization",
         "domains"
     ];
 

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -145,7 +145,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         return [
             "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
             "name" => "Organization Name",
-            "allowProfilesOutsideOrganization" => false,
+            "allow_profiles_outside_organization" => false,
             "domains" => [
                 [
                     "object" => "organization_domain",

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -24,7 +24,8 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
 
         $params = [
             "name" => "Organization Name",
-            "domains" => array("example.com")
+            "domains" => array("example.com"),
+            "allow_profiles_outside_organization" => null
         ];
 
         $this->mockRequest(

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -77,6 +77,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
             "name" => "Organization Name",
             "object" => "organization",
             "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
+            "allow_profiles_outside_organization" => false,
             "domains" => [
                 [
                     "object" => "organization_domain",
@@ -96,6 +97,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
                 "object" => "organization",
                 "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
                 "name" => "Organization Name",
+                "allow_profiles_outside_organization" => false,
                 "domains" => [
                     [
                         "object" => "organization_domain",
@@ -108,6 +110,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
                 "object" => "organization",
                 "id" => "org_01EHQMVDTC2GRAHFCCRNTSKH46",
                 "name" => "example2.com",
+                "allow_profiles_outside_organization" => false,
                 "domains" => [
                     [
                         "object" => "organization_domain",
@@ -120,6 +123,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
                 "object" => "organization",
                 "id" => "org_01EGP9Z6RY2J6YE0ZV57CGEXV2",
                 "name" => "example5.com",
+                "allow_profiles_outside_organization" => false,
                 "domains" => [
                     [
                         "object" => "organization_domain",
@@ -141,6 +145,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         return [
             "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
             "name" => "Organization Name",
+            "allow_profiles_outside_organization" => false,
             "domains" => [
                 [
                     "object" => "organization_domain",

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -145,7 +145,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         return [
             "id" => "org_01EHQMYV6MBK39QC5PZXHY59C3",
             "name" => "Organization Name",
-            "allow_profiles_outside_organization" => false,
+            "allowProfilesOutsideOrganization" => false,
             "domains" => [
                 [
                     "object" => "organization_domain",


### PR DESCRIPTION
This PR adds support for the `allowProfilesOutsideOrganization` field for organization objects and operations.

Resolves SDK-261.