### PR TITLE
Install PHP 7.2 before trying to use it

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
         - name: php 7.2
           commands:
             - phpbrew --no-progress install 7.2.34
-            - phpbrew use php-7.2
+            - phpbrew use php-7.2.34
             - bash scripts/restore-cache-and-update-deps 72
             - php composer.phar run-script test
         - name: php 7.4

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -35,9 +35,10 @@ blocks:
             - php composer.phar run-script test
         - name: php 7.2
           commands:
+            - phpbrew --no-progress install 7.2.34
             - phpbrew use php-7.2
             - bash scripts/restore-cache-and-update-deps 72
-            - composer run-script test
+            - php composer.phar run-script test
         - name: php 7.4
           commands:
             - phpbrew --no-progress install 7.4.12


### PR DESCRIPTION
This PR fixes an issue where we were trying to use PHP 7.2 prior to installing it in CI.