### PR TITLE
Bump to 1.4.0

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     const SDK_IDENTIFIER = "WorkOS PHP";
-    const SDK_VERSION = '1.3.0';
+    const SDK_VERSION = '1.4.0';
 }


### PR DESCRIPTION
Bumping to 1.4.0 to push a release including webhook validation and GET directory/:id function.