### PR TITLE
Add support for domain_hint and login_hint parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
+composer.phar
 vendor/

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -101,7 +101,7 @@ class Client
      * Generates a URL to the WorkOS API.
      *
      * @param string $path Path to the WorkOS resource
-     * @param null|array $params Associative arrray to be passed as query parameters
+     * @param null|array $params Associative array to be passed as query parameters
      *
      * @return string
      */

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -17,11 +17,20 @@ class SSO
      * @param null|array $state Associative array containing state that will be returned from WorkOS as a json encoded string
      * @param null|\WorkOS\Resource\ConnectionType $provider Service provider that handles the identity of the user
      * @param null|string $connection Unique identifier for a WorkOS Connection
+     * @param null|string $domainHint DDomain hint that will be passed as a parameter to the IdP login page
+     * @param null|string $loginHint Username/email hint that will be passed as a parameter to the to IdP login page
      *
      * @return string
      */
-    public function getAuthorizationUrl($domain, $redirectUri, $state, $provider, $connection)
-    {
+    public function getAuthorizationUrl(
+        $domain,
+        $redirectUri,
+        $state,
+        $provider,
+        $connection,
+        $domainHint = null,
+        $loginHint = null
+    ) {
         $authorizationPath = "sso/authorize";
 
         if (!isset($domain) && !isset($provider) && !isset($connection)) {
@@ -55,6 +64,14 @@ class SSO
             $params["connection"] = $connection;
         }
 
+        if ($domainHint) {
+            $params["domain_hint"] = $domainHint;
+        }
+
+        if ($loginHint) {
+            $params["login_hint"] = $loginHint;
+        }
+
         return Client::generateUrl($authorizationPath, $params);
     }
 
@@ -75,7 +92,7 @@ class SSO
             "code" => $code,
             "grant_type" => "authorization_code"
         ];
-        
+
         $response = Client::request(Client::METHOD_POST, $profilePath, null, $params);
 
         return Resource\ProfileAndToken::constructFromResponse($response);
@@ -98,7 +115,7 @@ class SSO
         $method = Client::METHOD_GET;
 
         $url = "https://api.workos.com/sso/profile";
-            
+
         $requestHeaders = ["Authorization: Bearer " . $accessToken];
 
         list($result) = Client::requestClient()->request(

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -19,8 +19,15 @@ class SSOTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider authorizationUrlTestProvider
      */
-    public function testAuthorizationURLExpectedParams($domain, $redirectUri, $state, $provider, $connection)
-    {
+    public function testAuthorizationURLExpectedParams(
+        $domain,
+        $redirectUri,
+        $state,
+        $provider,
+        $connection,
+        $domainHint = null,
+        $loginHint = null
+    ) {
         $expectedParams = [
             "client_id" => WorkOS::getClientId(),
             "response_type" => "code"
@@ -46,7 +53,23 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             $expectedParams["connection"] = $connection;
         }
 
-        $authorizationUrl = $this->sso->getAuthorizationUrl($domain, $redirectUri, $state, $provider, $connection);
+        if ($domainHint) {
+            $expectedParams["domain_hint"] = $domainHint;
+        }
+
+        if ($loginHint) {
+            $expectedParams["login_hint"] = $loginHint;
+        }
+
+        $authorizationUrl = $this->sso->getAuthorizationUrl(
+            $domain,
+            $redirectUri,
+            $state,
+            $provider,
+            $connection,
+            $domainHint,
+            $loginHint
+        );
         $paramsString = \parse_url($authorizationUrl, \PHP_URL_QUERY);
         \parse_str($paramsString, $paramsArray);
 
@@ -163,6 +186,8 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             ["papagenos.com", "https://papagenos.com/auth/callback", null, null, null],
             ["papagenos.com", "https://papagenos.com/auth/callback", ["toppings" => "ham"], null, null],
             [null, null, null, null, "connection_123"],
+            [null, "https://papagenos.com/auth/callback", null, null, "connection_123", "foo.com", null],
+            [null, "https://papagenos.com/auth/callback", null, null, "connection_123", null, "foo@workos.com"],
         ];
     }
 


### PR DESCRIPTION
Resolves SDK-382.

We should consider refactoring this method to consume a class/object for the parameters and then publishing a major version. Having this many arguments is no bueno.

We could also leverage the builder pattern here which is sometimes used in PHP.