### PR TITLE
Add organization parameter to GetAuthorizationURL

### DIFF
--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -29,14 +29,14 @@ class SSO
         $state,
         $provider,
         $connection,
-        $organization,
+        $organization = null,
         $domainHint = null,
         $loginHint = null
     ) {
         $authorizationPath = "sso/authorize";
 
-        if (!isset($domain) && !isset($provider) && !isset($connection)) {
-            $msg = "Either \$domain, \$provider, or \$connection is required";
+        if (!isset($domain) && !isset($provider) && !isset($connection) && !isset($organization)) {
+            $msg = "Either \$domain, \$provider, \$connection, or \$organization is required";
 
             throw new Exception\UnexpectedValueException($msg);
         }

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -44,7 +44,7 @@ class SSO
         if (isset($domain) && !isset($provider) && !isset($connection) && !isset($organization)) {
             $msg = "Domain is being deprecated, please switch to using Connection or Organization ID";
 
-            trigger_error($msg, E_USER_NOTICE);
+            error_log($msg);
         }
 
         $params = [
@@ -70,6 +70,10 @@ class SSO
 
         if ($connection) {
             $params["connection"] = $connection;
+        }
+
+        if ($organization) {
+            $params["organization"] = $organization;
         }
 
         if ($domainHint) {

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -41,7 +41,7 @@ class SSO
             throw new Exception\UnexpectedValueException($msg);
         }
 
-        if (isset($domain) && !isset($provider) && !isset($connection) && !isset($organization)) {
+        if (isset($domain)) {
             $msg = "Domain is being deprecated, please switch to using Connection or Organization ID";
 
             error_log($msg);

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -17,6 +17,7 @@ class SSO
      * @param null|array $state Associative array containing state that will be returned from WorkOS as a json encoded string
      * @param null|\WorkOS\Resource\ConnectionType $provider Service provider that handles the identity of the user
      * @param null|string $connection Unique identifier for a WorkOS Connection
+     * @param null|string $organization Unique identifier for a WorkOS Organization
      * @param null|string $domainHint DDomain hint that will be passed as a parameter to the IdP login page
      * @param null|string $loginHint Username/email hint that will be passed as a parameter to the to IdP login page
      *
@@ -28,6 +29,7 @@ class SSO
         $state,
         $provider,
         $connection,
+        $organization,
         $domainHint = null,
         $loginHint = null
     ) {
@@ -37,6 +39,12 @@ class SSO
             $msg = "Either \$domain, \$provider, or \$connection is required";
 
             throw new Exception\UnexpectedValueException($msg);
+        }
+
+        if (isset($domain) && !isset($provider) && !isset($connection) && !isset($organization)) {
+            $msg = "Domain is being deprecated, please switch to using Connection or Organization ID";
+
+            trigger_error($msg, E_USER_NOTICE);
         }
 
         $params = [

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -25,6 +25,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $state,
         $provider,
         $connection,
+        $organization,
         $domainHint = null,
         $loginHint = null
     ) {
@@ -67,6 +68,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             $state,
             $provider,
             $connection,
+            $organization,
             $domainHint,
             $loginHint
         );
@@ -186,6 +188,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             ["papagenos.com", "https://papagenos.com/auth/callback", null, null, null],
             ["papagenos.com", "https://papagenos.com/auth/callback", ["toppings" => "ham"], null, null],
             [null, null, null, null, "connection_123"],
+            [null, null, null, null, null, "org_01FG7HGMY2CZZR2FWHTEE94VF0"],
             [null, "https://papagenos.com/auth/callback", null, null, "connection_123", "foo.com", null],
             [null, "https://papagenos.com/auth/callback", null, null, "connection_123", null, "foo@workos.com"],
         ];

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -25,7 +25,70 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         $state,
         $provider,
         $connection,
-        $organization,
+        $organization = null,
+        $domainHint = null,
+        $loginHint = null
+    ) {
+        $expectedParams = [
+            "client_id" => WorkOS::getClientId(),
+            "response_type" => "code"
+        ];
+
+        if ($domain) {
+            $expectedParams["domain"] = $domain;
+        }
+
+        if ($redirectUri) {
+            $expectedParams["redirect_uri"] = $redirectUri;
+        }
+
+        if (null !== $state && !empty($state)) {
+            $expectedParams["state"] = \json_encode($state);
+        }
+
+        if ($provider) {
+            $expectedParams["provider"] = $provider;
+        }
+
+        if ($connection) {
+            $expectedParams["connection"] = $connection;
+        }
+
+        if ($domainHint) {
+            $expectedParams["domain_hint"] = $domainHint;
+        }
+
+        if ($loginHint) {
+            $expectedParams["login_hint"] = $loginHint;
+        }
+
+        $authorizationUrl = $this->sso->getAuthorizationUrl(
+            $domain,
+            $redirectUri,
+            $state,
+            $provider,
+            $connection,
+            $organization,
+            $domainHint,
+            $loginHint
+        );
+        $paramsString = \parse_url($authorizationUrl, \PHP_URL_QUERY);
+        \parse_str($paramsString, $paramsArray);
+
+        $this->assertSame($expectedParams, $paramsArray);
+    }
+
+    /**
+     * @dataProvider authorizationUrlTestProviderDomainWarning
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testAuthorizationURLDomainWarning(
+        $domain,
+        $redirectUri,
+        $state,
+        $provider,
+        $connection,
+        $organization = null,
         $domainHint = null,
         $loginHint = null
     ) {
@@ -183,10 +246,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
     public function authorizationUrlTestProvider()
     {
         return [
-            ["papagenos.com", null, null, null, null],
             [null, null, null, Resource\ConnectionType::GoogleOAuth, null],
-            ["papagenos.com", "https://papagenos.com/auth/callback", null, null, null],
-            ["papagenos.com", "https://papagenos.com/auth/callback", ["toppings" => "ham"], null, null],
             [null, null, null, null, "connection_123"],
             [null, null, null, null, null, "org_01FG7HGMY2CZZR2FWHTEE94VF0"],
             [null, "https://papagenos.com/auth/callback", null, null, "connection_123", "foo.com", null],
@@ -194,6 +254,14 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    public function authorizationUrlTestProviderDomainWarning()
+    {
+        return [
+            ["papagenos.com", "https://papagenos.com/auth/callback", null, null, null],
+            ["papagenos.com", null, null, null, null],
+            ["papagenos.com", "https://papagenos.com/auth/callback", ["toppings" => "ham"], null, null]
+        ];
+    }
     // Fixtures
 
     private function profileAndTokenResponseFixture()

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -54,67 +54,8 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             $expectedParams["connection"] = $connection;
         }
 
-        if ($domainHint) {
-            $expectedParams["domain_hint"] = $domainHint;
-        }
-
-        if ($loginHint) {
-            $expectedParams["login_hint"] = $loginHint;
-        }
-
-        $authorizationUrl = $this->sso->getAuthorizationUrl(
-            $domain,
-            $redirectUri,
-            $state,
-            $provider,
-            $connection,
-            $organization,
-            $domainHint,
-            $loginHint
-        );
-        $paramsString = \parse_url($authorizationUrl, \PHP_URL_QUERY);
-        \parse_str($paramsString, $paramsArray);
-
-        $this->assertSame($expectedParams, $paramsArray);
-    }
-
-    /**
-     * @dataProvider authorizationUrlTestProviderDomainWarning
-     * @expectedException PHPUnit_Framework_Error
-     */
-    public function testAuthorizationURLDomainWarning(
-        $domain,
-        $redirectUri,
-        $state,
-        $provider,
-        $connection,
-        $organization = null,
-        $domainHint = null,
-        $loginHint = null
-    ) {
-        $expectedParams = [
-            "client_id" => WorkOS::getClientId(),
-            "response_type" => "code"
-        ];
-
-        if ($domain) {
-            $expectedParams["domain"] = $domain;
-        }
-
-        if ($redirectUri) {
-            $expectedParams["redirect_uri"] = $redirectUri;
-        }
-
-        if (null !== $state && !empty($state)) {
-            $expectedParams["state"] = \json_encode($state);
-        }
-
-        if ($provider) {
-            $expectedParams["provider"] = $provider;
-        }
-
-        if ($connection) {
-            $expectedParams["connection"] = $connection;
+        if ($organization) {
+            $expectedParams["organization"] = $organization;
         }
 
         if ($domainHint) {
@@ -249,19 +190,14 @@ class SSOTest extends \PHPUnit\Framework\TestCase
             [null, null, null, Resource\ConnectionType::GoogleOAuth, null],
             [null, null, null, null, "connection_123"],
             [null, null, null, null, null, "org_01FG7HGMY2CZZR2FWHTEE94VF0"],
-            [null, "https://papagenos.com/auth/callback", null, null, "connection_123", "foo.com", null],
-            [null, "https://papagenos.com/auth/callback", null, null, "connection_123", null, "foo@workos.com"],
-        ];
-    }
-
-    public function authorizationUrlTestProviderDomainWarning()
-    {
-        return [
+            [null, "https://papagenos.com/auth/callback", null, null, "connection_123", null, "foo.com", null],
+            [null, "https://papagenos.com/auth/callback", null, null, "connection_123", null, null, "foo@workos.com"],
             ["papagenos.com", "https://papagenos.com/auth/callback", null, null, null],
             ["papagenos.com", null, null, null, null],
             ["papagenos.com", "https://papagenos.com/auth/callback", ["toppings" => "ham"], null, null]
         ];
     }
+
     // Fixtures
 
     private function profileAndTokenResponseFixture()


### PR DESCRIPTION
Add organization parameter to GetAuthorizationURL function and include a notice message in the function for users who are strictly calling via domain and not any other parameter to identify the connection. 