### PR TITLE
Remove utf-8 decode line 

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -45,8 +45,7 @@ class Webhook
         $signature = $this->getSignature($sigHeader);
 
         $currentTime = time();
-        $decodedBody = utf8_decode($payload);
-        $signedPayload = $timestamp . "." . $decodedBody;
+        $signedPayload = $timestamp . "." . $payload;
         $expectedSignature = hash_hmac("sha256", $signedPayload, $secret, false);
 
         if (empty($timestamp)):


### PR DESCRIPTION
Customer reported that a name with special characters (á, ó) are breaking the validateWebhook function. This PR will remove a line of code that calls utf8_decode which appears to be causing the issue.