### PR TITLE
Bump to 1.5.1

### DIFF
--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS;
 final class Version
 {
     const SDK_IDENTIFIER = "WorkOS PHP";
-    const SDK_VERSION = '1.5.0';
+    const SDK_VERSION = '1.5.1';
 }


### PR DESCRIPTION
1.5.1 fixes a bug in the Webhook::constructEvent function that was causing non utf8 characters to return an error.