### PR TITLE
Remove environment_id from SDK

### DIFF
--- a/lib/Resource/Directory.php
+++ b/lib/Resource/Directory.php
@@ -11,7 +11,6 @@ class Directory extends BaseWorkOSResource
 
     const RESOURCE_ATTRIBUTES = [
         "id",
-        "environmentId",
         "externalKey",
         "organizationId",
         "state",
@@ -22,7 +21,6 @@ class Directory extends BaseWorkOSResource
 
     const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
-        "environment_id" => "environmentId",
         "external_key" => "externalKey",
         "organization_id" => "organizationId",
         "state" => "state",

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -193,7 +193,6 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
             "data" => [
                 [
                     "id" => "directory_id",
-                    "environment_id" => "environment_123",
                     "external_key" => "fried-chicken",
                     "organization_id" => null,
                     "state" => "linked",
@@ -214,7 +213,6 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     {
         return [
             "id" => "directory_id",
-            "environmentId" => "environment_123",
             "externalKey" => "fried-chicken",
             "organizationId" => null,
             "state" => "linked",
@@ -228,7 +226,6 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     {
         return [
             "id" => "directory_id",
-            "environmentId" => "environment_123",
             "externalKey" => "fried-chicken",
             "organizationId" => null,
             "state" => "linked",
@@ -242,7 +239,6 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
     {
         return json_encode([
             "id" => "directory_id",
-            "environment_id" => "environment_123",
             "external_key" => "fried-chicken",
             "organization_id" => null,
             "state" => "linked",


### PR DESCRIPTION
isDirectories() throws an error as it's expecting environment_id to be passed as a value but it's no longer included within the response payload.  This causes an Undefined error for Array types when trying to reference the environment_id to write it to $instance->values

Where it's breaking:

https://github.com/workos-inc/workos-php/blob/2f2a44643dadd6159f864ddbbccf08a3e2301dfa/lib/Resource/BaseWorkOSResource.php#L35-L38

Where it needs to be fixed

https://github.com/workos-inc/workos-php/blob/2f2a44643dadd6159f864ddbbccf08a3e2301dfa/lib/Resource/Directory.php#L23-L31

Request where this code changed occurred

https://github.com/workos-inc/workos/pull/7422