### PR TITLE
Update dependencies for Laravel 9

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,12 +27,6 @@ blocks:
         commands:
           - checkout
       jobs:
-        - name: php 7.0
-          commands:
-            - phpbrew --no-progress install 7.0.33
-            - phpbrew use php-7.0.33
-            - bash scripts/restore-cache-and-update-deps 70
-            - php composer.phar run-script test
         - name: php 7.2
           commands:
             - phpbrew --no-progress install 7.2.34

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
   "require": {
     "php": ">=5.6.0",
     "ext-curl": "*",
-    "illuminate/support" : "^5.0 || ^6.0 || ^7.0 || ^8.0"
+    "illuminate/support" : "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.15",
-    "phpunit/phpunit": "^5.7"
+    "friendsofphp/php-cs-fixer": "^2.15|^3.6",
+    "phpunit/phpunit": "^5.7|^9.5.10"
   },
   "autoload": {
     "psr-4": {

--- a/lib/AuditTrail.php
+++ b/lib/AuditTrail.php
@@ -9,8 +9,8 @@ namespace WorkOS;
  */
 class AuditTrail
 {
-    const DEFAULT_EVENT_LIMIT = 10;
-    const METADATA_SIZE_LIMIT = 50;
+    public const DEFAULT_EVENT_LIMIT = 10;
+    public const METADATA_SIZE_LIMIT = 50;
 
     /**
      * Create an Audit Trail event. An event consists of the following fields:
@@ -166,7 +166,7 @@ class AuditTrail
             } elseif ($occurredAtGt) {
                 $params["occurred_at_gt"] = $occurredAtGt;
             }
-    
+
             if ($occurredAtLte) {
                 $params["occurred_at_lte"] = $occurredAtLte;
             } elseif ($occurredAtLt) {

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -9,10 +9,10 @@ namespace WorkOS;
  */
 class Client
 {
-    const METHOD_GET = "get";
-    const METHOD_POST = "post";
-    const METHOD_DELETE = "delete";
-    const METHOD_PUT = "put";
+    public const METHOD_GET = "get";
+    public const METHOD_POST = "post";
+    public const METHOD_DELETE = "delete";
+    public const METHOD_PUT = "put";
 
     private static $_requestClient;
 

--- a/lib/DirectorySync.php
+++ b/lib/DirectorySync.php
@@ -9,7 +9,7 @@ namespace WorkOS;
  */
 class DirectorySync
 {
-    const DEFAULT_PAGE_SIZE = 10;
+    public const DEFAULT_PAGE_SIZE = 10;
 
     /**
      * List Directories.

--- a/lib/Organizations.php
+++ b/lib/Organizations.php
@@ -9,7 +9,7 @@ namespace WorkOS;
  */
 class Organizations
 {
-    const DEFAULT_PAGE_SIZE = 10;
+    public const DEFAULT_PAGE_SIZE = 10;
 
     /**
      * List Organizations.

--- a/lib/Resource/Connection.php
+++ b/lib/Resource/Connection.php
@@ -7,9 +7,9 @@ namespace WorkOS\Resource;
  */
 class Connection extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "connection";
+    public const RESOURCE_TYPE = "connection";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "domains",
         "state",
@@ -19,7 +19,7 @@ class Connection extends BaseWorkOSResource
         "organizationId",
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "state" => "state",
         "status" => "status",

--- a/lib/Resource/ConnectionType.php
+++ b/lib/Resource/ConnectionType.php
@@ -9,17 +9,17 @@ namespace WorkOS\Resource;
  */
 class ConnectionType
 {
-    const ADFSSAML = "ADFSSAML";
-    const AzureSAML = "AzureSAML";
-    const GenericOIDC = "GenericOIDC";
-    const GenericSAML = "GenericSAML";
-    const GoogleOAuth = "GoogleOAuth";
-    const GoogleSAML = "GoogleSAML";
-    const MagicLink = "MagicLink";
-    const OneLoginSAML = "OneLoginSAML";
-    const OktaSAML = "OktaSAML";
-    const PingFederateSAML = "PingFederateSAML";
-    const PingOneSAML = "PingOneSAML";
-    const SalesforceSAML = "SalesforceSAML";
-    const VMwareSAML = "VMwareSAML";
+    public const ADFSSAML = "ADFSSAML";
+    public const AzureSAML = "AzureSAML";
+    public const GenericOIDC = "GenericOIDC";
+    public const GenericSAML = "GenericSAML";
+    public const GoogleOAuth = "GoogleOAuth";
+    public const GoogleSAML = "GoogleSAML";
+    public const MagicLink = "MagicLink";
+    public const OneLoginSAML = "OneLoginSAML";
+    public const OktaSAML = "OktaSAML";
+    public const PingFederateSAML = "PingFederateSAML";
+    public const PingOneSAML = "PingOneSAML";
+    public const SalesforceSAML = "SalesforceSAML";
+    public const VMwareSAML = "VMwareSAML";
 }

--- a/lib/Resource/Directory.php
+++ b/lib/Resource/Directory.php
@@ -7,9 +7,9 @@ namespace WorkOS\Resource;
  */
 class Directory extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "directory";
+    public const RESOURCE_TYPE = "directory";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "externalKey",
         "organizationId",
@@ -19,7 +19,7 @@ class Directory extends BaseWorkOSResource
         "domain"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "external_key" => "externalKey",
         "organization_id" => "organizationId",

--- a/lib/Resource/DirectoryGroup.php
+++ b/lib/Resource/DirectoryGroup.php
@@ -7,14 +7,14 @@ namespace WorkOS\Resource;
  */
 class DirectoryGroup extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "directory_grp";
+    public const RESOURCE_TYPE = "directory_grp";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "name"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "name" => "name"
     ];

--- a/lib/Resource/DirectoryUser.php
+++ b/lib/Resource/DirectoryUser.php
@@ -7,9 +7,9 @@ namespace WorkOS\Resource;
  */
 class DirectoryUser extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "directory_usr";
+    public const RESOURCE_TYPE = "directory_usr";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "rawAttributes",
         "customAttributes",
@@ -22,7 +22,7 @@ class DirectoryUser extends BaseWorkOSResource
         "groups"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "raw_attributes" => "rawAttributes",
         "custom_attributes" => "customAttributes",

--- a/lib/Resource/Domain.php
+++ b/lib/Resource/Domain.php
@@ -7,14 +7,14 @@ namespace WorkOS\Resource;
  */
 class Domain extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "connection_domain";
+    public const RESOURCE_TYPE = "connection_domain";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "domain"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "domain" => "domain"
     ];

--- a/lib/Resource/Event.php
+++ b/lib/Resource/Event.php
@@ -7,9 +7,9 @@ namespace WorkOS\Resource;
  */
 class Event extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "event";
+    public const RESOURCE_TYPE = "event";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "action",
         "group",
@@ -25,7 +25,7 @@ class Event extends BaseWorkOSResource
         "occurredAt",
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "group" => "group",
         "location" => "location",
@@ -56,7 +56,7 @@ class Event extends BaseWorkOSResource
 
         $eventAction = $eventArray["action"];
         $eventArray["action"] = $eventAction->toArray();
-        
+
         return $eventArray;
     }
 }

--- a/lib/Resource/EventAction.php
+++ b/lib/Resource/EventAction.php
@@ -7,15 +7,15 @@ namespace WorkOS\Resource;
  */
 class EventAction extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "event_action";
+    public const RESOURCE_TYPE = "event_action";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "environmentId",
         "name"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "environment_id" => "environmentId",
         "name" => "name"

--- a/lib/Resource/Organization.php
+++ b/lib/Resource/Organization.php
@@ -8,16 +8,16 @@ namespace WorkOS\Resource;
 
 class Organization extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "organization";
+    public const RESOURCE_TYPE = "organization";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "name",
         "allowProfilesOutsideOrganization",
         "domains"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "name" => "name",
         "allow_profiles_outside_organization" => "allowProfilesOutsideOrganization",

--- a/lib/Resource/PasswordlessSession.php
+++ b/lib/Resource/PasswordlessSession.php
@@ -7,9 +7,9 @@ namespace WorkOS\Resource;
  */
 class PasswordlessSession extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "passwordless_session";
+    public const RESOURCE_TYPE = "passwordless_session";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "email",
         "expiresAt",
@@ -17,7 +17,7 @@ class PasswordlessSession extends BaseWorkOSResource
         "object"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "email" => "email",
         "expires_at" => "expiresAt",

--- a/lib/Resource/PortalLink.php
+++ b/lib/Resource/PortalLink.php
@@ -7,13 +7,13 @@ namespace WorkOS\Resource;
  */
 class PortalLink extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "portal_link";
+    public const RESOURCE_TYPE = "portal_link";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "link"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "link" => "link"
     ];
 }

--- a/lib/Resource/Profile.php
+++ b/lib/Resource/Profile.php
@@ -7,9 +7,9 @@ namespace WorkOS\Resource;
  */
 class Profile extends BaseWorkOSResource
 {
-    const RESOURCE_TYPE = "profile";
+    public const RESOURCE_TYPE = "profile";
 
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "id",
         "email",
         "firstName",
@@ -21,7 +21,7 @@ class Profile extends BaseWorkOSResource
         "rawAttributes"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "id" => "id",
         "email" => "email",
         "first_name" => "firstName",

--- a/lib/Resource/ProfileAndToken.php
+++ b/lib/Resource/ProfileAndToken.php
@@ -7,12 +7,12 @@ namespace WorkOS\Resource;
  */
 class ProfileAndToken extends BaseWorkOSResource
 {
-    const RESOURCE_ATTRIBUTES = [
+    public const RESOURCE_ATTRIBUTES = [
         "accessToken",
         "profile"
     ];
 
-    const RESPONSE_TO_RESOURCE_KEY = [
+    public const RESPONSE_TO_RESOURCE_KEY = [
         "access_token" => "accessToken"
     ];
 

--- a/lib/Resource/Webhook.php
+++ b/lib/Resource/Webhook.php
@@ -9,8 +9,6 @@ namespace WorkOS\Resource;
  */
 class Webhook
 {
-    
-    
     /**
      * Creates a webhook object from a payload.
      *

--- a/lib/SSO.php
+++ b/lib/SSO.php
@@ -186,7 +186,7 @@ class SSO
         return Resource\Connection::constructFromResponse($response);
     }
 
-    const DEFAULT_PAGE_SIZE = 10;
+    public const DEFAULT_PAGE_SIZE = 10;
 
     /**
      * List Connections.

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -4,6 +4,6 @@ namespace WorkOS;
 
 final class Version
 {
-    const SDK_IDENTIFIER = "WorkOS PHP";
-    const SDK_VERSION = '1.7.0';
+    public const SDK_IDENTIFIER = "WorkOS PHP";
+    public const SDK_VERSION = '1.7.0';
 }

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -12,7 +12,6 @@ namespace WorkOS;
 
 class Webhook
 {
-   
     /** Initializes an Event object from a JSON payload
      * @param \WorkOS\Resource\Webhook
      *
@@ -69,7 +68,7 @@ class Webhook
         $timestamp = substr($workosHeadersSplit[0], 2);
         return $timestamp;
     }
-    
+
     /**
     * splits WorkOS headers two values and pulls out the signature value and returns it
     * @param $sigheader is the WorkOS header containing v1 signature and timestamp

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -7,7 +7,7 @@ trait TestHelper
     protected $defaultRequestClient;
     protected $requestClientMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->defaultRequestClient = Client::requestClient();
         $this->requestClientMock = $this->createMock("\WorkOS\RequestClient\RequestClientInterface");

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -13,7 +13,7 @@ trait TestHelper
         $this->requestClientMock = $this->createMock("\WorkOS\RequestClient\RequestClientInterface");
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         WorkOS::setApiKey(null);
         WorkOS::setClientId(null);

--- a/tests/WorkOS/AuditTrailTest.php
+++ b/tests/WorkOS/AuditTrailTest.php
@@ -11,16 +11,16 @@ class AuditTrailTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->traitSetUp();
-        
+
         $this->at = new AuditTrail();
     }
-    
+
     public function testCreateAuditTrailEvent()
     {
         $this->withApiKeyAndClientId();
 
         $path = "events";
-        
+
         $eventFixture = $this->eventFixture();
 
         $this->mockRequest(

--- a/tests/WorkOS/AuditTrailTest.php
+++ b/tests/WorkOS/AuditTrailTest.php
@@ -8,7 +8,7 @@ class AuditTrailTest extends \PHPUnit\Framework\TestCase
         setUp as protected traitSetUp;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/ClientTest.php
+++ b/tests/WorkOS/ClientTest.php
@@ -39,7 +39,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 
         $path = "some/place";
         $responseHeaders = ["x-request-id" => "123yocheckme"];
-        
+
         $this->mockRequest(
             Client::METHOD_GET,
             $path,

--- a/tests/WorkOS/DirectorySyncTest.php
+++ b/tests/WorkOS/DirectorySyncTest.php
@@ -8,7 +8,7 @@ class DirectorySyncTest extends \PHPUnit\Framework\TestCase
         setUp as traitSetUp;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -8,7 +8,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         setUp as protected traitSetUp;
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/OrganizationsTest.php
+++ b/tests/WorkOS/OrganizationsTest.php
@@ -8,7 +8,7 @@ class OrganizationsTest extends \PHPUnit\Framework\TestCase
         setUp as protected traitSetUp;
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/PasswordlessTest.php
+++ b/tests/WorkOS/PasswordlessTest.php
@@ -8,7 +8,7 @@ class PasswordlessTest extends \PHPUnit\Framework\TestCase
         setUp as traitSetUp;
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/PasswordlessTest.php
+++ b/tests/WorkOS/PasswordlessTest.php
@@ -8,7 +8,7 @@ class PasswordlessTest extends \PHPUnit\Framework\TestCase
         setUp as traitSetUp;
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/PortalTest.php
+++ b/tests/WorkOS/PortalTest.php
@@ -8,7 +8,7 @@ class PortalTest extends \PHPUnit\Framework\TestCase
         setUp as protected traitSetUp;
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/PortalTest.php
+++ b/tests/WorkOS/PortalTest.php
@@ -8,7 +8,7 @@ class PortalTest extends \PHPUnit\Framework\TestCase
         setUp as protected traitSetUp;
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/SSOTest.php
+++ b/tests/WorkOS/SSOTest.php
@@ -8,7 +8,7 @@ class SSOTest extends \PHPUnit\Framework\TestCase
         setUp as traitSetUp;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->traitSetUp();
 

--- a/tests/WorkOS/WebhookTest.php
+++ b/tests/WorkOS/WebhookTest.php
@@ -29,7 +29,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $result = $this->generateConnectionFixture();
 
         $expectation = '{"id":"wh_01FGCG6SDYCT5XWZT9CDW0XEB8","data":{"id":"conn_01EHWNC0FCBHZ3BJ7EGKYXK0E6","name":"Foo Corp\'s Connection","state":"active","object":"connection","domains":[{"id":"conn_domain_01EHWNFTAFCF3CQAE5A9Q0P1YB","domain":"foo-corp.com","object":"connection_domain"}],"connection_type":"OktaSAML","organization_id":"org_01EHWNCE74X7JSDV0X3SZ3KJNY"},"event":"connection.activated"}';
-        
+
         $response = $this->ap->constructEvent($headers, $payload, $secret, $tolerance);
         $this->assertSame($expectation, json_encode($response));
     }

--- a/tests/WorkOS/WebhookTest.php
+++ b/tests/WorkOS/WebhookTest.php
@@ -8,7 +8,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         setUp as protected traitSetUp;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->traitSetUp();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,3 @@
 <?php
+
 require_once __DIR__ . '/TestHelper.php';


### PR DESCRIPTION
Updating php-cs-fixer, phpunit, and illuminate/support packages for Laravel 9. Upgraded cs-fixer and phpunit have requirements that involved syntax changes in a number of files.