### PR TITLE
Add PHP 8.0 to CI pipeline, drop 7.2 no longer supported

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,15 +27,15 @@ blocks:
         commands:
           - checkout
       jobs:
-        - name: php 7.2
-          commands:
-            - phpbrew --no-progress install 7.2.34
-            - phpbrew use php-7.2.34
-            - bash scripts/restore-cache-and-update-deps 72
-            - php composer.phar run-script test
         - name: php 7.4
           commands:
             - phpbrew --no-progress install 7.4.12
             - phpbrew use php-7.4.12
             - bash scripts/restore-cache-and-update-deps 74
+            - php composer.phar run-script test
+        - name: php 8.0
+          commands:
+            - phpbrew --no-progress install 8.0.7
+            - phpbrew use php-8.0.7
+            - bash scripts/restore-cache-and-update-deps 80
             - php composer.phar run-script test


### PR DESCRIPTION
Update Semaphore CI pipeline to test for PHP 8.0. Removing test for 7.2 as it is no longer supported/maintained in any capacity.